### PR TITLE
Add option to return `idsOnly` document.

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,0 +1,33 @@
+name: Tests and Lint
+
+on:
+  push:
+    branches: ['main']
+
+  pull_request:
+    branches: ['main']
+
+env:
+  NODE_VERSION: 18
+
+jobs:
+  linting:
+    name: Tests+Linting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Code Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Code Linting
+        run: npm run lint
+
+      - name: Code Linting
+        run: npm test

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -27,7 +27,4 @@ jobs:
         run: npm ci
 
       - name: Code Linting
-        run: npm run lint
-
-      - name: Code Linting
         run: npm test

--- a/src/metal.ts
+++ b/src/metal.ts
@@ -50,7 +50,7 @@ class MetalSDK {
     return data;
   }
 
-  async search(payload: SearchPayload, appId?: string): Promise<object[]> {
+  async search(payload: SearchPayload, appId?: string, includeFullDocument: boolean): Promise<object[]> {
     const app = appId || this.appId;
     if (!app) {
       throw new Error('appId required');
@@ -70,7 +70,13 @@ class MetalSDK {
       body.text = text;
     }
 
-    const { data } = await axios.post(`${API_URL}/v1/search`, body, {
+    const url = `${API_URL}/v1/search`
+
+    if (includeFullDocument) {
+      url += '?includeDoc=true'
+    }
+
+    const { data } = await axios.post(url, body, {
       headers: {
         'Content-Type': 'application/json',
         'x-metal-api-key': this.apiKey,

--- a/src/metal.ts
+++ b/src/metal.ts
@@ -50,7 +50,7 @@ class MetalSDK {
     return data;
   }
 
-  async search(payload: SearchPayload, appId?: string, includeFullDocument?: boolean): Promise<object[]> {
+  async search(payload: SearchPayload, appId?: string, idsOnly?: boolean): Promise<object[]> {
     const app = appId || this.appId;
     if (!app) {
       throw new Error('appId required');
@@ -72,8 +72,8 @@ class MetalSDK {
 
     let url = `${API_URL}/v1/search`
 
-    if (includeFullDocument) {
-      url += '?includeDoc=true'
+    if (idsOnly) {
+      url += '?idsOnly=true'
     }
 
     const { data } = await axios.post(url, body, {

--- a/src/metal.ts
+++ b/src/metal.ts
@@ -50,7 +50,7 @@ class MetalSDK {
     return data;
   }
 
-  async search(payload: SearchPayload, appId?: string, includeFullDocument: boolean): Promise<object[]> {
+  async search(payload: SearchPayload, appId?: string, includeFullDocument?: boolean): Promise<object[]> {
     const app = appId || this.appId;
     if (!app) {
       throw new Error('appId required');
@@ -70,7 +70,7 @@ class MetalSDK {
       body.text = text;
     }
 
-    const url = `${API_URL}/v1/search`
+    let url = `${API_URL}/v1/search`
 
     if (includeFullDocument) {
       url += '?includeDoc=true'

--- a/tests/metal.test.ts
+++ b/tests/metal.test.ts
@@ -189,7 +189,7 @@ describe('MetalSDK', () => {
       );
     });
 
-    it('should add includeDoc=true querystring', async () => {
+    it('should add idsOnly=true querystring', async () => {
       const appId = 'app-id';
       const text = 'text-to-search';
       const metal = new MetalSDK(API_KEY, CLIENT_ID, appId);
@@ -199,7 +199,7 @@ describe('MetalSDK', () => {
       const result = await metal.search({ text }, undefined, true);
 
       expect(axios.post).toHaveBeenCalledWith(
-        'https://api.getmetal.io/v1/search?includeDoc=true',
+        'https://api.getmetal.io/v1/search?idsOnly=true',
         {
           text,
           app: appId,

--- a/tests/metal.test.ts
+++ b/tests/metal.test.ts
@@ -236,8 +236,9 @@ describe('MetalSDK', () => {
       const result = await metal.tune({ idA, idB, label });
 
       expect(axios.post).toHaveBeenCalledWith(
-        `https://api.getmetal.io/v1/apps/${appId}/tunings`,
+        `https://api.getmetal.io/v1/tune`,
         {
+          app: appId,
           idA,
           idB,
           label,

--- a/tests/metal.test.ts
+++ b/tests/metal.test.ts
@@ -188,6 +188,25 @@ describe('MetalSDK', () => {
         AXIOS_OPTS
       );
     });
+
+    it('should add includeDoc=true querystring', async () => {
+      const appId = 'app-id';
+      const text = 'text-to-search';
+      const metal = new MetalSDK(API_KEY, CLIENT_ID, appId);
+
+      axios.post = jest.fn(() => Promise.resolve({ data: null }));
+
+      const result = await metal.search({ text }, undefined, true);
+
+      expect(axios.post).toHaveBeenCalledWith(
+        'https://api.getmetal.io/v1/search?includeDoc=true',
+        {
+          text,
+          app: appId,
+        },
+        AXIOS_OPTS
+      );
+    });
   });
 
   describe('tune()', () => {


### PR DESCRIPTION
- Include full document by default
- Adds `idsOnly` option to fetch only the `ids`