### PR TITLE
Add `getOne`

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -3,6 +3,5 @@ module.exports = {
   tabWidth: 2,
   singleQuote: true,
   semi: false,
-  jsxBracketSameLine: true,
   trailingComma: 'es5',
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@getmetal/metal-sdk",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "description": "Metal SDK",
     "scripts": {
         "prettier": "prettier -c .",

--- a/package.json
+++ b/package.json
@@ -1,50 +1,50 @@
 {
-    "name": "@getmetal/metal-sdk",
-    "version": "1.0.14",
-    "description": "Metal SDK",
-    "scripts": {
-        "prettier": "prettier -c .",
-        "format": "prettier -w .",
-        "prepare": "npm run build",
-        "lint": "eslint .",
-        "lint:fix": "eslint . --fix",
-        "build": "tsc",
-        "test": "jest \"tests/.*\\.test\\.ts\" --coverage --collectCoverageFrom=src/**/*.ts",
-        "publish": "npm publish  --access public"
-    },
-    "license": "Apache 2.0",
-    "keywords": [],
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/getmetal/metal-sdk.git"
-    },
-    "homepage": "https://getmetal.io",
-    "files": [
-        "dist"
-    ],
-    "main": "dist/src/metal.js",
-    "types": "dist/src/metal.d.ts",
-    "author": "Metal <founders@getmetal.io> (https://getmetal.io/)",
-    "devDependencies": {
-        "@types/jest": "^29.4.0",
-        "@typescript-eslint/eslint-plugin": "^5.50.0",
-        "eslint": "^8.33.0",
-        "eslint-config-prettier": "^8.6.0",
-        "eslint-config-standard-with-typescript": "^34.0.0",
-        "eslint-plugin-import": "^2.27.5",
-        "eslint-plugin-n": "^15.6.1",
-        "eslint-plugin-prettier": "^4.2.1",
-        "eslint-plugin-promise": "^6.1.1",
-        "jest": "^29.4.3",
-        "prettier": "^2.8.3",
-        "ts-jest": "^29.0.5",
-        "ts-node": "^10.9.1",
-        "typescript": "^4.9.5"
-    },
-    "dependencies": {
-        "axios": "^1.3.2"
-    },
-    "bugs": {
-        "url": "https://github.com/getmetal/metal-sdk/issues"
-    }
+  "name": "@getmetal/metal-sdk",
+  "version": "1.0.14",
+  "description": "Metal SDK",
+  "scripts": {
+    "prettier": "prettier -c .",
+    "format": "prettier -w .",
+    "prepare": "npm run build",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "build": "tsc",
+    "test": "jest \"tests/.*\\.test\\.ts\" --coverage --collectCoverageFrom=src/**/*.ts",
+    "publish": "npm publish  --access public"
+  },
+  "license": "Apache 2.0",
+  "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getmetal/metal-sdk.git"
+  },
+  "homepage": "https://getmetal.io",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/src/metal.js",
+  "types": "dist/src/metal.d.ts",
+  "author": "Metal <founders@getmetal.io> (https://getmetal.io/)",
+  "devDependencies": {
+    "@types/jest": "^29.4.0",
+    "@typescript-eslint/eslint-plugin": "^5.50.0",
+    "eslint": "^8.33.0",
+    "eslint-config-prettier": "^8.6.0",
+    "eslint-config-standard-with-typescript": "^34.0.0",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-n": "^15.6.1",
+    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-promise": "^6.1.1",
+    "jest": "^29.4.3",
+    "prettier": "^2.8.3",
+    "ts-jest": "^29.0.5",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.9.5"
+  },
+  "dependencies": {
+    "axios": "^1.3.2"
+  },
+  "bugs": {
+    "url": "https://github.com/getmetal/metal-sdk/issues"
+  }
 }

--- a/src/metal.ts
+++ b/src/metal.ts
@@ -121,6 +121,27 @@ class MetalSDK {
 
     return data
   }
+
+  async getOne(id: string, appId?: string): Promise<object> {
+    const app = appId ?? this.appId
+    if (!app) {
+      throw new Error('appId required')
+    }
+
+    if (!id) {
+      throw new Error('id required')
+    }
+
+    const { data } = await axios.get(`${API_URL}/v1/documents/${id}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        'x-metal-api-key': this.apiKey,
+        'x-metal-client-id': this.clientId,
+      },
+    })
+
+    return data
+  }
 }
 
 export default MetalSDK

--- a/src/metal.ts
+++ b/src/metal.ts
@@ -122,12 +122,7 @@ class MetalSDK {
     return data
   }
 
-  async getOne(id: string, appId?: string): Promise<object> {
-    const app = appId ?? this.appId
-    if (!app) {
-      throw new Error('appId required')
-    }
-
+  async getOne(id: string): Promise<object> {
     if (!id) {
       throw new Error('id required')
     }

--- a/tests/metal.test.ts
+++ b/tests/metal.test.ts
@@ -248,4 +248,35 @@ describe('MetalSDK', () => {
       )
     })
   })
+
+  describe('getOne()', () => {
+    it('should error without appId', async () => {
+      const metal = new MetalSDK(API_KEY, CLIENT_ID)
+      const result = metal.getOne('megadeth')
+      await expect(result).rejects.toThrowError('appId required')
+    })
+
+    it('should error without `id`', async () => {
+      const metal = new MetalSDK(API_KEY, CLIENT_ID, 'app-id')
+      // @ts-expect-error testing
+      const result = metal.getOne()
+      await expect(result).rejects.toThrowError('id required')
+    })
+
+    it('should get one by id', async () => {
+      const appId = 'app-id'
+      const metal = new MetalSDK(API_KEY, CLIENT_ID, appId)
+
+      mockedAxios.get.mockResolvedValue({
+        data: { id: 'megadeth', metadata: { vocalist: 'Dave Mustain' } },
+      })
+
+      await metal.getOne('megadeth')
+
+      expect(axios.get).toHaveBeenCalledWith(
+        `https://api.getmetal.io/v1/documents/megadeth`,
+        AXIOS_OPTS
+      )
+    })
+  })
 })

--- a/tests/metal.test.ts
+++ b/tests/metal.test.ts
@@ -250,12 +250,6 @@ describe('MetalSDK', () => {
   })
 
   describe('getOne()', () => {
-    it('should error without appId', async () => {
-      const metal = new MetalSDK(API_KEY, CLIENT_ID)
-      const result = metal.getOne('megadeth')
-      await expect(result).rejects.toThrowError('appId required')
-    })
-
     it('should error without `id`', async () => {
       const metal = new MetalSDK(API_KEY, CLIENT_ID, 'app-id')
       // @ts-expect-error testing
@@ -264,8 +258,7 @@ describe('MetalSDK', () => {
     })
 
     it('should get one by id', async () => {
-      const appId = 'app-id'
-      const metal = new MetalSDK(API_KEY, CLIENT_ID, appId)
+      const metal = new MetalSDK(API_KEY, CLIENT_ID)
 
       mockedAxios.get.mockResolvedValue({
         data: { id: 'megadeth', metadata: { vocalist: 'Dave Mustain' } },


### PR DESCRIPTION
Adds `getOne` method to SDK. This method uses the `/v1/documents/:id` endpoint to fetch a single record from the API.