### PR TITLE
Fix package types to index.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "main": "dist/cjs/src/index.js",
   "module": "dist/esm/src/index.js",
-  "types": "dist/esm/src/types.d.ts",
+  "types": "dist/esm/src/index.d.ts",
   "author": "Metal <founders@getmetal.io> (https://getmetal.io/)",
   "devDependencies": {
     "@types/jest": "^29.4.0",


### PR DESCRIPTION
Hi thank you for developing awsome Vector database😆

Especially, I like these features of metal:

- No need to directly handle Vector (it is automatically embedded)
- Ability to view record contents (text converted from vector) on the UI

By the way, while using this SDK, I noticed that the `Metal` type was not exported.

![CleanShot 2023-06-17 at 22 46 35@2x](https://github.com/getmetal/metal-ts/assets/6919381/1c824798-88c2-4ea3-9a4f-17fb0769035f)

It seems to be a problem with the `types` in `package.json`, so I fixed it.
(Regarding `types.ts` being an internal type, I don't think it needs to be exported externally, but is this correct?)
![CleanShot 2023-06-17 at 22 47 13@2x](https://github.com/getmetal/metal-ts/assets/6919381/9c1861ee-74e8-4d83-9559-94abed795545)

