### PR TITLE
Filters v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getmetal/metal-sdk",
-  "version": "5.0.11",
+  "version": "6.0.0",
   "description": "Metal SDK",
   "scripts": {
     "prettier": "prettier -c .",

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,9 +55,17 @@ export interface BulkIndexPayload {
   data: IndexPayload[]
 }
 
+export type Operator = 'eq' | 'gt' | 'gte' | 'lt' | 'lte'
+
 export interface Filter {
   field: string
+  operator: Operator
   value: string | number
+}
+
+export interface Filters {
+  and?: Filter[]
+  or?: Filter[]
 }
 
 export interface SearchInput {
@@ -66,7 +74,7 @@ export interface SearchInput {
   imageUrl?: string
   text?: string
   embedding?: number[]
-  filters?: Filter[]
+  filters?: Filters
   idsOnly?: boolean
   limit?: number
 }
@@ -77,7 +85,7 @@ export interface SearchPayload {
   imageUrl?: string
   text?: string
   embedding?: number[]
-  filters?: Filter[]
+  filters?: Filters
 }
 
 export interface TuningInput {

--- a/tests/metal.test.ts
+++ b/tests/metal.test.ts
@@ -300,14 +300,14 @@ describe('Metal', () => {
 
       mockedAxios.post.mockResolvedValue({ data: null })
 
-      await metal.search({ text, filters: [{ field: 'favoriteNumber', value: 666 }] })
+      await metal.search({ text, filters: { and: [{ field: 'favoriteNumber', operator: 'lt', value: 666 }] } })
 
       expect(axios.post).toHaveBeenCalledWith(
         'https://api.getmetal.io/v1/search?limit=10',
         {
           text,
           index: indexId,
-          filters: [{ field: 'favoriteNumber', value: 666 }],
+          filters: { and: [{ field: 'favoriteNumber', operator: 'lt', value: 666 }] },
         },
         AXIOS_OPTS
       )

--- a/tests/metal.test.ts
+++ b/tests/metal.test.ts
@@ -300,7 +300,10 @@ describe('Metal', () => {
 
       mockedAxios.post.mockResolvedValue({ data: null })
 
-      await metal.search({ text, filters: { and: [{ field: 'favoriteNumber', operator: 'lt', value: 666 }] } })
+      await metal.search({
+        text,
+        filters: { and: [{ field: 'favoriteNumber', operator: 'lt', value: 666 }] },
+      })
 
       expect(axios.post).toHaveBeenCalledWith(
         'https://api.getmetal.io/v1/search?limit=10',


### PR DESCRIPTION
Adds `and` and `or` clauses.

With `eq` `gt` `gte` `lte` an `lt` operators.

Breaks how we handle filters, but bumps major version change.