### PR TITLE
Wrap `fetch` to reject on `!response.ok`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getmetal/metal-sdk",
-  "version": "7.0.2",
+  "version": "7.1.0",
   "description": "Metal SDK",
   "engineStrict": true,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getmetal/metal-sdk",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Metal SDK",
   "engineStrict": true,
   "engines": {

--- a/src/metal.ts
+++ b/src/metal.ts
@@ -1,6 +1,7 @@
 import mime from 'mime-types'
 import { API_URL, SUPPORTED_FILE_TYPES } from './constants'
 import { sanitizeFilename } from './helpers'
+import { request } from './request'
 import {
   type Client,
   type IndexInput,
@@ -58,7 +59,7 @@ export class Metal implements Client {
       body.embedding = embedding
     }
 
-    const res = await fetch(`${API_URL}/v1/index`, {
+    const data = await request(`${API_URL}/v1/index`, {
       method: 'POST',
       body: JSON.stringify(body),
       headers: {
@@ -68,14 +69,13 @@ export class Metal implements Client {
       },
     })
 
-    const json = await res.json()
-    return json?.data ?? json
+    return data
   }
 
   async indexMany(payload: IndexPayload[]): Promise<object> {
     const body: BulkIndexPayload = { data: payload }
 
-    const res = await fetch(`${API_URL}/v1/index/bulk`, {
+    const data = await request(`${API_URL}/v1/index/bulk`, {
       method: 'POST',
       body: JSON.stringify(body),
       headers: {
@@ -85,8 +85,7 @@ export class Metal implements Client {
       },
     })
 
-    const json = await res.json()
-    return json?.data ?? json
+    return data
   }
 
   async search(payload: SearchInput = {}): Promise<object[]> {
@@ -113,7 +112,7 @@ export class Metal implements Client {
       url += '&idsOnly=true'
     }
 
-    const res = await fetch(url, {
+    const data = await request(url, {
       method: 'POST',
       body: JSON.stringify(body),
       headers: {
@@ -123,8 +122,7 @@ export class Metal implements Client {
       },
     })
 
-    const json = await res.json()
-    return json?.data ?? json
+    return data
   }
 
   async tune(payload: TuningInput): Promise<object> {
@@ -139,7 +137,7 @@ export class Metal implements Client {
 
     const body: TuningPayload = { index, ...payload }
 
-    const res = await fetch(`${API_URL}/v1/tune`, {
+    const data = await request(`${API_URL}/v1/tune`, {
       method: 'POST',
       body: JSON.stringify(body),
       headers: {
@@ -149,8 +147,7 @@ export class Metal implements Client {
       },
     })
 
-    const json = await res.json()
-    return json?.data ?? json
+    return data
   }
 
   async getOne(id: string, indexId?: string): Promise<object> {
@@ -164,7 +161,7 @@ export class Metal implements Client {
       throw new Error('indexId required')
     }
 
-    const res = await fetch(`${API_URL}/v1/indexes/${index}/documents/${id}`, {
+    const data = await request(`${API_URL}/v1/indexes/${index}/documents/${id}`, {
       headers: {
         'Content-Type': 'application/json',
         'x-metal-api-key': this.apiKey,
@@ -172,8 +169,7 @@ export class Metal implements Client {
       },
     })
 
-    const json = await res.json()
-    return json?.data ?? json
+    return data
   }
 
   async deleteOne(id: string, indexId?: string): Promise<object> {
@@ -187,7 +183,7 @@ export class Metal implements Client {
       throw new Error('indexId required')
     }
 
-    const res = await fetch(`${API_URL}/v1/indexes/${index}/documents/${id}`, {
+    const data = await request(`${API_URL}/v1/indexes/${index}/documents/${id}`, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
@@ -196,8 +192,7 @@ export class Metal implements Client {
       },
     })
 
-    const json = await res.json()
-    return json?.data
+    return data
   }
 
   async deleteMany(ids: string[], indexId?: string): Promise<object> {
@@ -210,7 +205,7 @@ export class Metal implements Client {
       throw new Error('ids required')
     }
 
-    const res = await fetch(`${API_URL}/v1/indexes/${index}/documents/bulk`, {
+    const data = await request(`${API_URL}/v1/indexes/${index}/documents/bulk`, {
       method: 'DELETE',
       body: JSON.stringify({ ids }),
       headers: {
@@ -220,8 +215,7 @@ export class Metal implements Client {
       },
     })
 
-    const json = await res.json()
-    return json?.data ?? json
+    return data
   }
 
   private async createResource(payload: CreateResourcePayload): Promise<CreateFileResouceResponse> {
@@ -239,14 +233,13 @@ export class Metal implements Client {
       'x-metal-client-id': this.clientId,
     }
 
-    const res = await fetch(url, {
+    const data = await request(url, {
       method: 'POST',
       body: JSON.stringify(body),
       headers,
     })
 
-    const json = await res.json()
-    return json?.data ?? json
+    return data
   }
 
   private async uploadFileToUrl(payload: UploadFileToUrlPayload): Promise<object> {
@@ -257,14 +250,13 @@ export class Metal implements Client {
       'content-length': fileSize.toString(),
     }
 
-    const res = await fetch(url, {
+    const data = await request(url, {
       method: 'PUT',
-      body: file, // TODO: Confirm this..does it need to be jsonified?
+      body: file,
       headers,
     })
 
-    const json = await res.json()
-    return json?.data ?? json
+    return data
   }
 
   async uploadFile(file: UploadFilePayload, indexId?: string): Promise<object> {

--- a/src/motorhead.ts
+++ b/src/motorhead.ts
@@ -1,5 +1,6 @@
 import { API_URL } from './constants'
 import { type MotorheadClient, type MotorheadConfig, type Memory } from './types'
+import { request } from './request'
 
 const MANAGED_BASE_URL = `${API_URL}/v1/motorhead`
 
@@ -20,7 +21,7 @@ export class Motorhead implements MotorheadClient {
   }
 
   async addMemory(sessionId: string, payload: Memory): Promise<Memory> {
-    const res = await fetch(`${this.baseUrl}/sessions/${sessionId}/memory`, {
+    const data = await request(`${this.baseUrl}/sessions/${sessionId}/memory`, {
       method: 'POST',
       body: JSON.stringify(payload),
       headers: {
@@ -30,12 +31,11 @@ export class Motorhead implements MotorheadClient {
       } as any,
     })
 
-    const json = await res.json()
-    return json?.data ?? json
+    return data
   }
 
   async getMemory(sessionId: string): Promise<Memory> {
-    const res = await fetch(`${this.baseUrl}/sessions/${sessionId}/memory`, {
+    const data = await request(`${this.baseUrl}/sessions/${sessionId}/memory`, {
       headers: {
         'Content-Type': 'application/json',
         'x-metal-api-key': this.apiKey,
@@ -43,12 +43,11 @@ export class Motorhead implements MotorheadClient {
       } as any,
     })
 
-    const json = await res.json()
-    return json?.data ?? json
+    return data
   }
 
   async deleteMemory(sessionId: string): Promise<void> {
-    const res = await fetch(`${this.baseUrl}/sessions/${sessionId}/memory`, {
+    const data = await request(`${this.baseUrl}/sessions/${sessionId}/memory`, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
@@ -57,8 +56,7 @@ export class Motorhead implements MotorheadClient {
       } as any,
     })
 
-    const json = await res.json()
-    return json?.data ?? json
+    return data
   }
 }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,0 +1,31 @@
+interface ServerResponse {
+  data?: any
+  message?: string
+}
+
+class FetchError extends Error {
+  response: Response
+  status: number
+  serverMessage?: string
+
+  constructor(message: string, response: Response, status: number, serverMessage?: string) {
+    super(message)
+    this.name = 'FetchError'
+    this.response = response
+    this.status = status
+    this.serverMessage = serverMessage
+  }
+}
+
+export async function request(url: string, options: RequestInit): Promise<any> {
+  const response: Response = await fetch(url, options)
+  const data: ServerResponse = await response.json()
+
+  if (!response.ok) {
+    const errMsg = `Error status code: ${response.status}. ${data.message ?? ''}`.trim()
+    const err = new FetchError(errMsg, response, response.status, data.message)
+    throw err
+  }
+
+  return data?.data ?? data
+}

--- a/tests/motorhead.test.ts
+++ b/tests/motorhead.test.ts
@@ -6,6 +6,7 @@ const fetchMock = jest.spyOn(global, 'fetch')
 const getMockRes = (data: any) => async (): Promise<Response> => {
   return (await Promise.resolve({
     json: async () => await Promise.resolve({ data }),
+    ok: true,
   })) as Response
 }
 


### PR DESCRIPTION
- After moving from `axios` to `fetch` we stopped rejecting failed requests.
- This makes requests where `response.ok` is false to reject.