### PR TITLE
Update `getMany` to return array consistently

### DIFF
--- a/src/metal.ts
+++ b/src/metal.ts
@@ -205,6 +205,10 @@ export class Metal implements Client {
       },
     })
 
+    if (!Array.isArray(data)) {
+      return [data]
+    }
+
     return data
   }
 

--- a/tests/metal.test.ts
+++ b/tests/metal.test.ts
@@ -537,7 +537,7 @@ describe('Metal', () => {
       await expect(result).rejects.toThrowError('indexId required')
     })
 
-    it('should get one by id', async () => {
+    it('should get multiple by id', async () => {
       const metal = new Metal(API_KEY, CLIENT_ID, 'index-id')
 
       fetchMock.mockImplementationOnce(
@@ -551,6 +551,25 @@ describe('Metal', () => {
 
       expect(fetchMock).toHaveBeenCalledWith(
         `https://api.getmetal.io/v1/indexes/index-id/documents/megadeth,ironmaiden`,
+        {
+          headers: HEADERS,
+        }
+      )
+    })
+
+    it('should get one by id', async () => {
+      const metal = new Metal(API_KEY, CLIENT_ID, 'index-id')
+
+      fetchMock.mockImplementationOnce(
+        getMockRes({ id: 'megadeth', metadata: { vocalist: 'Dave Mustain' } })
+      )
+
+      const res = await metal.getMany(['megadeth'])
+
+      expect(Array.isArray(res)).toBe(true)
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://api.getmetal.io/v1/indexes/index-id/documents/megadeth`,
         {
           headers: HEADERS,
         }


### PR DESCRIPTION
Fixes case where a single `id` is provided to `getMany` and it doesn't return an array.